### PR TITLE
8722 custom js docs

### DIFF
--- a/doc/sphinx-guides/source/admin/metadatacustomization.rst
+++ b/doc/sphinx-guides/source/admin/metadatacustomization.rst
@@ -571,6 +571,8 @@ Configuration involves specifying which fields are to be mapped, whether free-te
 These are all defined in the :ref:`:CVocConf <:CVocConf>` setting as a JSON array. Details about the required elements as well as example JSON arrays are available at https://github.com/gdcc/dataverse-external-vocab-support, along with an example metadata block that can be used for testing.
 The scripts required can be hosted locally or retrieved dynamically from https://gdcc.github.io/ (similar to how dataverse-previewers work).
 
+Please note that in addition to the :ref:`:CVocConf` described above, an alternative is the :ref:`:ControlledVocabularyCustomJavaScript` setting.
+
 Tips from the Dataverse Community
 ---------------------------------
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -2808,20 +2808,22 @@ Scripts that implement this association for specific service protocols are maint
 
 ``curl -X PUT --upload-file cvoc-conf.json http://localhost:8080/api/admin/settings/:CVocConf``
 
+.. _:ControlledVocabularyCustomJavaScript:
+
 :ControlledVocabularyCustomJavaScript
 +++++++++++++++++++++++++++++++++++++
 
-We can have controlled vocabulary as a list locally (with optionally translated values). But if the list is large and needs to be maintained, it is more advantageous to have, for example, a lookup functionality that allows to search for the values at an external service. We can have external controlled vocabularies with "skosmos" protocol (or other, using URI bound terms), but this is an overkill for a simple list (enumeration) for one field (e.g., author name using author lookup) that does not have any translations or URIs.
+``:ControlledVocabularyCustomJavaScript`` allows a JavaScript file to be loaded into the dataset page for the purpose of showing controlled vocabulary as a list (with optionally translated values) such as author names.
 
-A more desirable solution is to allow a custom JavaScript to control values of specific fields.
+To specify the URL for a custom script ``covoc.js`` to be loaded from an external site:
 
-To specify a custom script ``/covoc/js/covoc.js`` to be loaded:
+``curl -X PUT -d 'https://example.com/js/covoc.js' http://localhost:8080/api/admin/settings/:ControlledVocabularyCustomJavaScript``
 
-``curl -X PUT -d '/covoc/js/covoc.js' http://localhost:8080/api/admin/settings/:ControlledVocabularyCustomJavaScript``
+To remove the custom script URL:
 
-To remove the custom script:
+``curl -X DELETE http://localhost:8080/api/admin/settings/:ControlledVocabularyCustomJavaScript``
 
-``curl -X PUT -d '' http://localhost:8080/api/admin/settings/:ControlledVocabularyCustomJavaScript``
+Please note that :ref:`:CVocConf` is a better option if the list is large or needs to be searchable from an external service using protocols such as SKOSMOS.
 
 .. _:AllowedCurationLabels:
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -2808,6 +2808,21 @@ Scripts that implement this association for specific service protocols are maint
 
 ``curl -X PUT --upload-file cvoc-conf.json http://localhost:8080/api/admin/settings/:CVocConf``
 
+:ControlledVocabularyCustomJavaScript
++++++++++++++++++++++++++++++++++++++
+
+We can have controlled vocabulary as a list locally (with optionally translated values). But if the list is large and needs to be maintained, it is more advantageous to have, for example, a lookup functionality that allows to search for the values at an external service. We can have external controlled vocabularies with "skosmos" protocol (or other, using URI bound terms), but this is an overkill for a simple list (enumeration) for one field (e.g., author name using author lookup) that does not have any translations or URIs.
+
+A more desirable solution is to allow a custom JavaScript to control values of specific fields.
+
+To specify a custom script ``/covoc/js/covoc.js`` to be loaded:
+
+``curl -X PUT -d '/covoc/js/covoc.js' http://localhost:8080/api/admin/settings/:ControlledVocabularyCustomJavaScript``
+
+To remove the custom script:
+
+``curl -X PUT -d '' http://localhost:8080/api/admin/settings/:ControlledVocabularyCustomJavaScript``
+
 .. _:AllowedCurationLabels:
 
 :AllowedCurationLabels
@@ -2958,18 +2973,3 @@ The URL of an LDN Inbox to which the LDN Announce workflow step will send messag
 ++++++++++++++++++++++++++
 
 The list of parent dataset field names for which the LDN Announce workflow step should send messages. See :doc:`/developers/workflows` for details.
-
-:ControlledVocabularyCustomJavaScript
-+++++++++++++++++++++++++++++++++++++
-
-We can have controlled vocabulary as a list locally (with optionally translated values). But if the list is large and needs to be maintained, it is more advantageous to have, for example, a lookup functionality that allows to search for the values at an external service. We can have external controlled vocabularies with "skosmos" protocol (or other, using URI bound terms), but this is an overkill for a simple list (enumeration) for one field (e.g., author name using author lookup) that does not have any translations or URIs.
-
-A more desirable solution is to allow a custom JavaScript to control values of specific fields.
-
-To specify a custom script ``/covoc/js/covoc.js`` to be loaded:
-
-``curl -X PUT -d '/covoc/js/covoc.js' http://localhost:8080/api/admin/settings/:ControlledVocabularyCustomJavaScript``
-
-To remove the custom script:
-
-``curl -X PUT -d '' http://localhost:8080/api/admin/settings/:ControlledVocabularyCustomJavaScript``


### PR DESCRIPTION
Hi @ErykKul 

Rather than bashing on https://github.com/IQSS/dataverse/pull/8723 directly I thought I'd make a pull request.

I tweaked the docs in the following ways:

- Add a link to the new setting from Admin Guide.
- Move the new setting closer to :CVocConf since it's so related.
- Simply the wording (I hope).
- Change the example to an external URL because I don't know where `/covoc/js/covoc.js` should be on the filesystem. (I'm curious where you put it or what you do.)

Thanks.