### PR TITLE
Add timing metrics to measure indexing load

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
This is how this will look like at the `/metrics` endpoint, ready to be read by Prometheus or other libraries:

```
# TYPE index_permit_wait_time_seconds_mean gauge
index_permit_wait_time_seconds_mean{mp_scope="application"} 6.3490000000000005E-6
# TYPE index_permit_wait_time_seconds_max gauge
# HELP index_permit_wait_time_seconds_max Displays how long does it take to receive a permit to index a dataset
index_permit_wait_time_seconds_max{mp_scope="application"} 1.10023E-4
# TYPE index_permit_wait_time_seconds summary
# HELP index_permit_wait_time_seconds Displays how long does it take to receive a permit to index a dataset
index_permit_wait_time_seconds_count{mp_scope="application"} 2
index_permit_wait_time_seconds_sum{mp_scope="application"} 1.1548E-4
index_permit_wait_time_seconds{mp_scope="application",quantile="0.5"} 5.4570000000000004E-6
index_permit_wait_time_seconds{mp_scope="application",quantile="0.75"} 5.4570000000000004E-6
index_permit_wait_time_seconds{mp_scope="application",quantile="0.95"} 5.4570000000000004E-6
index_permit_wait_time_seconds{mp_scope="application",quantile="0.98"} 5.4570000000000004E-6
index_permit_wait_time_seconds{mp_scope="application",quantile="0.99"} 5.4570000000000004E-6
index_permit_wait_time_seconds{mp_scope="application",quantile="0.999"} 1.10023E-4
# TYPE index_time_seconds_mean gauge
index_time_seconds_mean{mp_scope="application"} 0.249897494
# TYPE index_time_seconds_max gauge
# HELP index_time_seconds_max Displays how long does it take to index a dataset
index_time_seconds_max{mp_scope="application"} 0.439255001
# TYPE index_time_seconds summary
# HELP index_time_seconds Displays how long does it take to index a dataset
index_time_seconds_count{mp_scope="application"} 2
index_time_seconds_sum{mp_scope="application"} 0.687522403
index_time_seconds{mp_scope="application",quantile="0.5"} 0.248267402
index_time_seconds{mp_scope="application",quantile="0.75"} 0.248267402
index_time_seconds{mp_scope="application",quantile="0.95"} 0.248267402
index_time_seconds{mp_scope="application",quantile="0.98"} 0.248267402
index_time_seconds{mp_scope="application",quantile="0.99"} 0.248267402
index_time_seconds{mp_scope="application",quantile="0.999"} 0.439255001
```

We're not yet on a Payara server supporting MPM 5.1, otherwise we could also add automatic histograms. If we are interested in these right now, we can add them manually. Not sure if we want to expose more information like number of files in a dataset or similar, to further track down what's going on.